### PR TITLE
Sprint ExpressoMail 7 e 8

### DIFF
--- a/expressoMail/inc/class.imap_functions.inc.php
+++ b/expressoMail/inc/class.imap_functions.inc.php
@@ -1272,6 +1272,11 @@ class imap_functions
 		}
 
 		$header_ = imap_fetchheader($this->mbox, $msg_number, FT_UID);
+
+        $calendar = false;
+        $calendar = preg_match("/AgendaExpresso: (\d+)/", $header_);
+        $calendar = $calendar || preg_match("/DiretoAgenda:/", $header_);
+
 		$return_get_body = $this->get_body_msg($msg_number, mb_convert_encoding( $msg_folder, "ISO-8859-1", "UTF-8" ));
 		$body = $return_get_body['body'];
 		if($return_get_body['body']=='isCripted'){
@@ -1284,7 +1289,7 @@ class imap_functions
 			//return $return;
 		}else{
 	    $return['body'] 		= $body;
-	    $return['attachments'] 	= $return_get_body['attachments'];
+	    $return['attachments'] 	= $calendar ? '' : $return_get_body['attachments'];
 	    $return['thumbs'] 		= $return_get_body['thumbs'];
 	    //$return['signature']	= $return_get_body['signature'];
 		}
@@ -3472,6 +3477,9 @@ class imap_functions
             }
             else
                 $mailService->setBodyText(mb_convert_encoding($body, 'ISO-8859-1' , 'UTF-8,ISO-8859-1' ));
+
+			$mailService->addHeaderField('Message-ID', "<". md5(uniqid(time())) . "@" .
+										 $_SERVER['SERVER_NAME'] . ">\n");
 
             if ($is_important)
                 $mailService->addHeaderField('Importance', 'High');

--- a/expressoMail/inc/class.ldap_functions.inc.php
+++ b/expressoMail/inc/class.ldap_functions.inc.php
@@ -1230,13 +1230,13 @@ class ldap_functions
             $justthese = array($corporatesignature);
             $sr = @ldap_search($this->ds, $this->ldap_context, $filter, $justthese);
             if(!$sr) {
-                return false;
+                return '';
             }
             $info = ldap_get_entries($this->ds, $sr);
             $info[0][$corporatesignature][0] = utf8_decode($info[0][$corporatesignature][0]);
             return $info[0][$corporatesignature][0];
         }
-        return "";
+        return '';
     }
 
     function get_alternative_emails_ldap(){

--- a/expressoMail/inc/get_archive.php
+++ b/expressoMail/inc/get_archive.php
@@ -11,7 +11,7 @@ if(!isset($GLOBALS['phpgw_info']))
     );
 }
 include_once(dirname(__FILE__).'/../../prototype/library/utils/Logger.php');
-$GLOBALS['phpgw_info']['server']['download_temp_dir'] = '/tmp';
+$GLOBALS['phpgw_info']['server']['download_temp_dir'] = '/var/www/tmp';
 //-----------------------//
 
 //-----------------------//
@@ -58,16 +58,16 @@ else
 function unhtmlentities($string)
 {
     $string = utf8_encode($string);
-    
+
     static $trans_tbl;
- 
+
     $string = preg_replace('~&#x([0-9a-f]+);~ei', 'code2utf(hexdec("\\1"))', $string);
     $string = preg_replace('~&#([0-9]+);~e', 'code2utf(\\1)', $string);
 
     if (!isset($trans_tbl))
         {
         $trans_tbl = array();
-       
+
         foreach (get_html_translation_table(HTML_ENTITIES) as $val=>$key)
             $trans_tbl[$key] = utf8_encode($val);
         }
@@ -98,7 +98,7 @@ if($msgNumber != 'null' && $indexPart !== null && $msgFolder)
     $attachment->setStructureFromMail($msgFolder, $msgNumber);
     $fileContent = $attachment->getAttachment($indexPart);
     $info = $attachment->getAttachmentInfo($indexPart);
-    $filename = $newFilename ? $newFilename : $info['name'];       
+    $filename = $newFilename ? $newFilename : $info['name'];
     $filename = unhtmlentities($filename);
     $messageId = $attachment->messageId;
 }
@@ -124,7 +124,7 @@ $disposition = $image ? "inline" : "attachment; filename=\"". addslashes($newFil
 
 if( !$ContentType || $ContentType == 'application/octet-stream')
 {
-    
+
     if( strstr($_SERVER['HTTP_USER_AGENT'],'MSIE') && $disposition != 'inline' )
         $ContentType = 'application-download';
                 else
@@ -132,7 +132,7 @@ if( !$ContentType || $ContentType == 'application/octet-stream')
         function guessContentType( $fileName )
         {
             $strFileType = strtolower(substr ( $fileName , strrpos($fileName, '.') ));
-                         
+
 	    switch( $strFileType )
 	    {
 		case ".asf": return "video/x-ms-asf";
@@ -210,13 +210,13 @@ if( $fileContent )
 {
 	$size = mb_strlen($fileContent);
     header("Content-Length: ". $size);
-    
+
     if( isset($info["encoding"]) )
     {
         header("Content-transfer-encoding: ".$info["encoding"] );
     //    header("Content-encoding: ".$info["encoding"] );
-    } 
-    
+    }
+
     if( $image === 'thumbnail'  && (strtolower(substr ( $info['name'] , (strrpos($info['name'], '.')+1))) !== 'bmp') )
     {
 	$pic = imagecreatefromstring( $fileContent );
@@ -243,10 +243,10 @@ if( $fileContent )
 	echo $fileContent;
 }
 else
-{   
+{
     /**
     * Delete Diretorio
-    * @param string $dir 
+    * @param string $dir
     */
     function cleanup( $dir )
     {
@@ -259,7 +259,7 @@ else
                 cleanup( $dir.'/'.$file );
 
         reset( $files ); //?
-        
+
         if(!rmdir( $dir ))
             return;
     }
@@ -275,8 +275,8 @@ else
 
     $size = filesize($filename);
     header("Content-Length: ". $size);
-    header("Content-encoding: text/plain" ); 
-    
+    header("Content-encoding: text/plain" );
+
     if (preg_match("#^".$tempDir."/(".$GLOBALS['phpgw']->session->sessionid."/)*[A-z0-9_]+_".$GLOBALS['phpgw']->session->sessionid."[A-z0-9]*(\.[A-z]{3,4})?$#",$filename))
     {
         session_write_close();
@@ -303,7 +303,7 @@ if(!$filename||$filename='false'){
 	Logger::info('expressomail', 'gotodownload','id:'.$messageId.'|filename:'.$filename.'|size:'.$size);
 }
 
-        
+
 //-----------------------//
 
 ?>

--- a/expressoMail/index.php
+++ b/expressoMail/index.php
@@ -384,7 +384,6 @@
 		echo '<link rel="stylesheet" type="text/css" href="../contactcenter/styles/search_persons.css"/>';
 	}
 
-
 	if ( isset($GLOBALS['phpgw_info']['user']['preferences']['expressoMail']['use_shortcuts']) ) //usar teclas de atalho ?
 	{
 		echo '<script type="text/javascript" src="js/shortcut.js" ></script>';

--- a/expressoMail/js/common_functions.js
+++ b/expressoMail/js/common_functions.js
@@ -92,11 +92,13 @@ function resizeWindow()
 			if( div.length )
 			{
 				div.css('height',(clientHeight - (div.position().top + (table_message.clientHeight ? table_message.clientHeight : table_message.offsetHeight)+2)) + "px");
+				div.css('width',(clientWidth - (div.position().left+10)) + "px");
 			}
 
 			if( div_scroll.length )
 			{
 				div_scroll.css('height', (clientHeight - (div_scroll.position().top + (table_message.clientHeight ? table_message.clientHeight : table_message.offsetHeight)+5)) + "px");
+				div_scroll.css('width',(clientWidth - (div_scroll.position().left+15)) + "px");
 			}
 		}
 	}

--- a/expressoMail/js/doiMenuData.js
+++ b/expressoMail/js/doiMenuData.js
@@ -192,7 +192,6 @@
                     "remove": {"name": get_lang("Delete"),      "icon": "delete", callback: function(key, opt){ proxy_mensagens.delete_msgs('null','selected','null'); }},
                     "export": {"name": get_lang("Export"),      "icon": "export", callback: function(key, opt){ proxy_mensagens.export_all_messages(); }},
 					/*Abre o diálogo de criação de filtro a partir da mensagem:*/
-					/*
 					"filterFromMsg": {
 						"name": get_lang("Create filter from message"),
 						"icon": "filter",
@@ -206,7 +205,6 @@
 						},
 						disabled: is_filterFromMsg_disabled()
 					},
-					*/
                     "archive": archive
                 }
 

--- a/expressoMail/js/rich_text_editor.js
+++ b/expressoMail/js/rich_text_editor.js
@@ -303,7 +303,7 @@ cRichTextEditor.prototype.setInitData = function (id,data,dataType,recursion, ca
 			$('#'+id).val(data);
 		}
 		else{
-			setTimeout(function() {RichTextEditor.setInitData(id,data,dataType,recursion); }, 500);
+			setTimeout(function() {RichTextEditor.setInitData(id,data,dataType,recursion,callback); }, 500);
 		}
 	}  
 	else{
@@ -320,15 +320,12 @@ cRichTextEditor.prototype.setInitData = function (id,data,dataType,recursion, ca
 			var divBr = '<div style="'+fontSize+fontFamily+'"><br type="_moz"></div>';
 			
 			if(dataType == 'edit')
-				editor.setData(data , null , false);
+				editor.setData(data , callback);
 			else
-				editor.setData(divBr+data , null , false);
-			
-			if(callback !== undefined)
-				callback();
+				editor.setData(divBr+divBr+data , callback);
 		}
 		else if(recursion < 20){
-			setTimeout(function() {RichTextEditor.setInitData(id,data,dataType,recursion); }, 500);
+			setTimeout(function() {RichTextEditor.setInitData(id,data,dataType,recursion,callback); }, 500);
 		}
 	} 
 }

--- a/expressoMail/js/searchEmails.js
+++ b/expressoMail/js/searchEmails.js
@@ -1376,7 +1376,7 @@ searchE.prototype.quickSearchMail = function(value, page, sort, border_id)
 				//Não deve fazer filtro de mensagens por TAG em pastas compartilhadas
 				if( i === "folder_id" ){ 
 					if(folders[key][i].indexOf("user.")>-1){
-						if(value.indexOf("$Label")<0){
+						if(value && value.indexOf("$Label")<0){
 						nm_box[nm_box.length] = folders[key][i]; 
 
 						}

--- a/expressoMail/setup/phpgw_pt-br.lang
+++ b/expressoMail/setup/phpgw_pt-br.lang
@@ -920,6 +920,7 @@ No name filled	expressoMail	pt-br	Nenhum nome preenchido
 No criteria filled	expressoMail	pt-br	Nenhum critério preenchido
 Invalid name, 'vacation' is a reserved word	expressoMail	pt-br	Nome inválido, 'vacation' é uma palavra reservada
 There is already a filter with this name	expressoMail	pt-br	Já existe um filtro com este nome
+Invalid name, use only letters and numbers	expressoMail	pt-br	Nome inválido, use somente letras ou números
 Fill the action value	expressoMail	pt-br	Preencha o valor da ação
 This user is already blocked. Would you like to unlock it?	expressoMail	pt-br	Esse usuário já está bloqueado. Deseja desbloquea-lo?
 Lock User	expressoMail	pt-br	Bloqueio do usuário
@@ -931,8 +932,8 @@ Exclusion Confirmation	expressoMail	pt-br	Confirmação de exclusão
 List	expressoMail	pt-br	Listagem
 Rules for message classification	expressoMail	pt-br	Regras de classificação de mensagem
 Add new rule	expressoMail	pt-br	Adicionar nova regra
-Add rule out of office	expressoMail	pt-br	Adicionar regra Fora do escritorio
-Out of office	expressoMail	pt-br	Fora do escritorio
+Add rule out of office	expressoMail	pt-br	Adicionar regra Fora do escritório
+Out of office	expressoMail	pt-br	Fora do escritório
 Do you want to display date in format numerical?	expressoMail	pt-br	Você deseja exibir a data no formato numérico?
 at	expressoMail	pt-br	às
 Remove Label	expressoMail	pt-br	Desmarcar

--- a/expressoMail/templates/default/main.css
+++ b/expressoMail/templates/default/main.css
@@ -314,7 +314,7 @@ pre{
 	word-wrap: break-word !important; /* Internet Explorer 5.5+ */
 	font-family: monospace !important;
 	/*font-size: 10pt !important;*/
-	font-size: 11px !important;
+	font-size: 13px !important;
 }
 /** {
 	font-family: Verdana, Arial, Helvetica, sans-serif;

--- a/prototype/config/Tonic.srv
+++ b/prototype/config/Tonic.srv
@@ -70,6 +70,9 @@ TokenResource = /oauth/TokenResource.php
 [/usercontacts]
 UserContactsResource = /catalog/UserContactsResource.php
 
+[/userdynamiccontacts]
+UserDynamicContactsResource = /catalog/UserDynamicContactsResource.php
+
 [/usersldap]
 UsersResource = /user/UsersResource.php
 

--- a/prototype/modules/filters/edit-filter.ejs
+++ b/prototype/modules/filters/edit-filter.ejs
@@ -15,7 +15,7 @@
 		<div>
 			<fieldset>
 				<label class="small"><%= get_lang("Name of the rule")%></label>
-				<input type="text" name="name" />
+				<input type="text" name="name" size="30" maxlength="30"/>
 			</fieldset>
 			<fieldset>
 				<label class="small"><%= get_lang("Sender")%></label>
@@ -27,7 +27,7 @@
 					<option value="$"><%= get_lang("ends with")%></option>
 
 				</select>
-				<input type="text" name="criteriaValue[]" value="<%= data.from %>" />
+				<input type="text" name="criteriaValue[]" value="<%= data.from %>" size="50" />
 				<input type="hidden" name="criteriaType[]" value="from"/>
 			</fieldset>
 			<fieldset>
@@ -39,7 +39,7 @@
 					<option value="^"><%= get_lang("starting with")%></option>
 					<option value="$"><%= get_lang("ends with")%></option>
 				</select>
-				<input type="text" name="criteriaValue[]" />
+				<input type="text" name="criteriaValue[]" size="50" />
 				<input type="hidden" name="criteriaType[]" value="to"/>
 			</fieldset>
 			<fieldset>
@@ -52,7 +52,7 @@
 					<option value="$"><%= get_lang("ends with")%></option>
 
 				</select>
-				<input type="text" name="criteriaValue[]" value="<%= data.subject %>" />
+				<input type="text" name="criteriaValue[]" value="<%= data.subject %>" size="50" />
 				<input type="hidden" name="criteriaType[]" value="subject"/>
 			</fieldset>
 			<fieldset>
@@ -64,7 +64,7 @@
 					<option value="^"><%= get_lang("starting with")%></option>
 					<option value="$"><%= get_lang("ends with")%></option>
 				</select>
-				<input type="text" name="criteriaValue[]" />
+				<input type="text" name="criteriaValue[]" size="50" />
 				<input type="hidden" name="criteriaType[]" value="body"/>
 			</fieldset>
 			<fieldset>
@@ -73,7 +73,7 @@
 					<option value=">"><%= get_lang("is over than")%></option>
 					<option value="<"><%= get_lang("is under than")%></option>
 				</select>
-				<input type="text" class="sizeRule" name="criteriaValue[]" />
+				<input type="text" class="sizeRule" name="criteriaValue[]" size="7" maxlength="7" />
 				<input type="hidden" name="criteriaType[]" value="size"/>
 			</fieldset>
 			<fieldset>

--- a/prototype/modules/filters/filter-list.ejs
+++ b/prototype/modules/filters/filter-list.ejs
@@ -37,7 +37,7 @@
 			<ul class="menu-control">
 				<li><a href="#<%= data.rules[i].name %>" class="button update" title="<%= get_lang("Change rule")%> '<%= (data.rules[i].name ? (data.rules[i].name == 'vacation' ? get_lang('vacation') : data.rules[i].name) : data.rules[i].id)%>'"></a></li>
 				<li><a href="#<%= data.rules[i].name %>" class="button enable<%= (data.rules[i].enabled == "true")? '': ' hidden' %>" title="<%= get_lang("Disable rule")%> '<%= (data.rules[i].name ? (data.rules[i].name == 'vacation' ? get_lang('vacation') : data.rules[i].name) : data.rules[i].id)%>'"></a></li>
-				<li><a href="#<%= data.rules[i].name %>" class="button disable<%= (data.rules[i].enabled  == "true")? ' hidden': '' %>" title="<%= get_lang("Enable rule")%>"></a></li>
+				<li><a href="#<%= data.rules[i].name %>" class="button disable<%= (data.rules[i].enabled  == "true")? ' hidden': '' %>" title="<%= get_lang("Enable rule")%> '<%= (data.rules[i].name ? (data.rules[i].name == 'vacation' ? get_lang('vacation') : data.rules[i].name) : data.rules[i].id)%>'"></a></li>
 				<li><a href="#<%= data.rules[i].name %>" class="button close" title="<%= get_lang("Delete rule")%> '<%= (data.rules[i].name ? (data.rules[i].name == 'vacation' ? get_lang('vacation') : data.rules[i].name) : data.rules[i].id)%>'"></a></li>
 				<li class="select" ><input type="checkbox"/></li>
 			</ul>
@@ -52,7 +52,7 @@
 	
 %>
 		<% if(data.rules[i].id == "") continue; %>
-		<li class="rule" title="<%= data.rules[i].id %>">
+		<li class="rule" title="<%= data.rules[i].name %>">
 			<strong class="title <%= (data.rules[i].enabled == "true")? 'enable':'disable' %>"><%= (data.rules[i].name ? data.rules[i].name : data.rules[i].id)%></strong>
 			<input type="hidden" class="id" value="<%= data.rules[i].id %>">
 			<dl class="rule-briefing">
@@ -111,10 +111,10 @@
 			</dl>
 			<ul class="menu-control">
 				<li><a href="#<%= data.rules[i].name %>" class="button update" title="<%= get_lang("Change rule")%> '<%= data.rules[i].name %>'"></a></li>
-				<li><a href="#<%= data.rules[i].name %>" class="button enable<%= (data.rules[i].enabled == "true")? '': ' hidden' %>" title="<%= get_lang("Disable rule")%>"></a></li>
-				<li><a href="#<%= data.rules[i].name %>" class="button disable<%= (data.rules[i].enabled  == "true")? ' hidden': '' %>" title="<%= get_lang("Enable rule")%>"></a></li>
+				<li><a href="#<%= data.rules[i].name %>" class="button enable<%= (data.rules[i].enabled == "true")? '': ' hidden' %>" title="<%= get_lang("Disable rule")%> '<%= data.rules[i].name %>'"></a></li>
+				<li><a href="#<%= data.rules[i].name %>" class="button disable<%= (data.rules[i].enabled  == "true")? ' hidden': '' %>" title="<%= get_lang("Enable rule")%> '<%= data.rules[i].name %>'"></a></li>
 				<li><a href="#<%= data.rules[i].name %>" class="button close" title="<%= get_lang("Delete rule")%> '<%= data.rules[i].name %>'"></a></li>
-				<li class="select" ><input type="checkbox"/></li>
+				<li class="select" ><input type="checkbox" title="<%= data.rules[i].name %>"/></li>
 			</ul>
 		</li>
 <% 

--- a/prototype/modules/filters/interceptors/FilterMapping.php
+++ b/prototype/modules/filters/interceptors/FilterMapping.php
@@ -65,19 +65,19 @@ class FilterMapping
 	* @author     Consórcio Expresso Livre - 4Linux (www.4linux.com.br) e Prognus Software Livre (www.prognus.com.br)
 	* @sponsor    Caixa Econômica Federal
 	* @author     Airton Bordin Junior <airton@prognus.com.br>
-	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>	
-	* @author	  Natan Fonseca <natan@prognus.com.br>	
-	* @param      <$uri> 
-	* @param      <$result> 
-	* @param      <$criteria> 
-	* @param      <$original> 
+	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>
+	* @author	  Natan Fonseca <natan@prognus.com.br>
+	* @param      <$uri>
+	* @param      <$result>
+	* @param      <$criteria>
+	* @param      <$original>
 	* @access     <public>
 	*/
 	public function makeId(&$uri , &$result , &$criteria , $original) {
 		$result['id'] = $uri['id'];
 	}
-	
-	
+
+
 	/**
 	* Método que formata o Script de acordo com a sintaxe do Sieve.
 	*
@@ -85,7 +85,7 @@ class FilterMapping
 	* @author     Consórcio Expresso Livre - 4Linux (www.4linux.com.br) e Prognus Software Livre (www.prognus.com.br)
 	* @sponsor    Caixa Econômica Federal
 	* @author     Airton Bordin Junior <airton@prognus.com.br>
-	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>	
+	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>
 	* @param      <Array> <$rules> <Array com as regras do usuário>
 	* @return     <Regra de acordo com a sintaxe do Sieve>
 	* @access     <public>
@@ -95,18 +95,18 @@ class FilterMapping
 		$require_fileinto = $require_flag = $require_reject = $require_vacation = $require_body = $require_imapflag = $vacation = $startswith = $endswith = false;
 		$script_rules = $script_header = $script_criteria = $vacation_action = "";
 		$i = 0;
-		
+
 		foreach( $rules as $name => $data )
-		{	
+		{
 			if( $data['enabled'] == 'false' )
 				continue;
-				
-			if(array_key_exists("block", $data)) 
+
+			if(array_key_exists("block", $data))
 			{
 				/* Usado na opção Bloquear usuário do ExpressoMail */
 				if($data['block']) {
 					($i >0) ? $script_match = 'elsif anyof' : $script_match = 'if anyof';
-					$script_match = $script_match . "(address :is \"from\" [\"" .$data['name'] . "\"]) {\r\n";  
+					$script_match = $script_match . "(address :is \"from\" [\"" .$data['name'] . "\"]) {\r\n";
 					$script_match .= "fileinto \"INBOX/Spam\"; \r\n}\r\n";
 					$script_rules .= $script_match;
 					$script_match = "";
@@ -116,49 +116,50 @@ class FilterMapping
 					continue;
 				}
 			}
-			
 
-				
+
+
 			$vacation = false;
 			$criteria = $data['criteria'];
 			$action   = $data['actions'];
-			
+
 			($i >0 && $verifyNextRule == 'false') ? $script_match = 'els' : $script_match = '';
 			$data['isExact'] == 'false' ?  $script_match .= 'if anyof (' : $script_match .= 'if allof (';
 
 			$verifyNextRule = 'false';
-			
+
 			if( is_array($criteria) )
 			foreach ($criteria as $j => $value)
-			{					
+			{
 				if ($criteria[$j]['operator'] == '!*') $script_criteria .= "not ";
-				
+
 				switch(strtoupper($criteria[$j]['field'])) {
-					case 'TO':    
+					case 'TO':
 					case 'CC':
-						$criteria[$j]['field'] = "[\"To\", \"TO\", \"Cc\", \"CC\"]"; 
+						$criteria[$j]['field'] = "[\"To\", \"TO\", \"Cc\", \"CC\"]";
 						$script_criteria .= "address :";
 						break;
 					case 'FROM':
 						$criteria[$j]['field'] = "\"" . $criteria[$j]['field'] . "\"";
 						$script_criteria .= "address :";
 						break;
-					case 'SIZE':	
+					case 'SIZE':
 						$criteria[$j]['field'] = '';
 						$script_criteria .= "size :";
 						break;
 					case 'SUBJECT':
 						$criteria[$j]['field'] = "\"" . $criteria[$j]['field'] . "\"";
+						$criteria[$j]['value'] = mb_convert_encoding($criteria[$j]['value'], 'ISO-8859-1', 'UTF-8');
 						$script_criteria .= "header :";
 						if($criteria[$j]['operator'] == "$") {
-							$criteria[$j]['value'] = "" . $criteria[$j]['value'] . "\", \"*" . base64_encode($criteria[$j]['value']) . "";
+							$criteria[$j]['value'] = "" . $this->convert_specialchar($criteria[$j]['value']) . "\", \"*" . base64_encode($criteria[$j]['value']) . "";
 							break;
 						}
 						if($criteria[$j]['operator'] == "^") {
-							$criteria[$j]['value'] = "" . $criteria[$j]['value'] . "*\", \"" . base64_encode($criteria[$j]['value']) . "";
+							$criteria[$j]['value'] = "" . $this->convert_specialchar($criteria[$j]['value']) . "*\", \"" . base64_encode($criteria[$j]['value']) . "";
 							break;
 						}
-						$criteria[$j]['value'] = "" . $criteria[$j]['value'] . "\", \"" . base64_encode($criteria[$j]['value']) . "";
+						$criteria[$j]['value'] = "" . $this->convert_specialchar($criteria[$j]['value']) . "\", \"" . base64_encode($criteria[$j]['value']) . "";
 						break;
 					case 'BODY':
 						$criteria[$j]['field'] = '';
@@ -177,7 +178,7 @@ class FilterMapping
 						$script_criteria .= "header :";
 						break;
 				}
-				
+
 				switch ($criteria[$j]['operator']) {
 					case '>':
 						$criteria[$j]['operator'] = "over";
@@ -194,7 +195,7 @@ class FilterMapping
 					case '*':
 						$criteria[$j]['operator'] = "contains";
 						$criteria[$j]['value'] = "[\"" . $criteria[$j]['value'] . "\"]";
-						break;						
+						break;
 					case '^':
 						$criteria[$j]['operator'] = "matches";
 						$criteria[$j]['value'] = "[\"" . $criteria[$j]['value'] . "*\"]";
@@ -215,24 +216,24 @@ class FilterMapping
 						$criteria[$j]['value'] = "[\"" . $criteria[$j]['value'] . "\"]";
 						break;
 				}
-				
+
 				if ($criteria[$j]['field'] == "" || $criteria[$j]['field'] == "\"subject\"" || $startswith || $endswith)
 				{
-					$script_criteria .= $criteria[$j]['operator'] . " " . $criteria[$j]['field'] . " " . $criteria[$j]['value'] . ", "; 
+					$script_criteria .= $criteria[$j]['operator'] . " " . $criteria[$j]['field'] . " " . $criteria[$j]['value'] . ", ";
 					$startswith = $endswith = false;
 				}
 				else
 					$script_criteria .= $criteria[$j]['operator'] . " " . $criteria[$j]['field'] . " " . $criteria[$j]['value'] . ", ";
 			}
 			$script_criteria = substr($script_criteria,0,-2);
-			$script_criteria .= ")"; 
+			$script_criteria .= ")";
 
 			$action_addFlag = '';
-			
+
 			// 			[parameter] => 7
 			// 			[type] => markLabel
-			
-			
+
+
 			if( is_array($action) )
 			foreach ($action as $k => $value)
 			{
@@ -247,7 +248,7 @@ class FilterMapping
 						$require_flag = true;
 						$action[$k]['parameter'] = "\\\\" . $action[$k]['parameter'];
 						break;
-					case 'addflag':	
+					case 'addflag':
 						$require_flag = true;
 						$action_addFlag = "addflag \"" . $action[$k]['parameter'] . "\";\r\n ";
 						break;
@@ -258,7 +259,7 @@ class FilterMapping
 						break;
 					case 'fileinto':
 						$require_fileinto = true;
-						$action[$k]['parameter'] = mb_convert_encoding($action[$k]['parameter'], "UTF7-IMAP","UTF-8, ISO-8859-1, UTF7-IMAP"); 
+						$action[$k]['parameter'] = mb_convert_encoding($action[$k]['parameter'], "UTF7-IMAP","UTF-8, ISO-8859-1, UTF7-IMAP");
 						break;
 					case 'vacation':
 						$require_vacation = true;
@@ -273,17 +274,17 @@ class FilterMapping
 					$script_action .= $action[$k]['type'].";\r\n";
 				}
 				elseif ($vacation == false && $action[$k]['type'] != 'addflag' && $action[$k]['type']!='markLabel'){
-					$script_action .= $action[$k]['type'] . " \"" . $action[$k]['parameter'] . "\";\r\n ";
+					$script_action .= $action[$k]['type'] . " \"" . $action[$k]['parameter'] . "\";\r\n";
 				}elseif ($vacation == false && $action[$k]['type']=='markLabel'){
-					$script_action .= "setflag" . " \"" . $action[$k]['parameter'] . "\";\r\n ";
+					$script_action .= "setflag" . " \"" . $action[$k]['parameter'] . "\";\r\n";
 				}
 			}
-			
-			
+
+
 			/* ATENÇÃO: Colocar sempre o comando addflag antes de qualquer outro no caso de ações compostas no Sieve */
-			if ($action_addFlag != '') $script_action = $action_addFlag . $script_action; 
-			
-			$script_action = "{\r\n " . $script_action . "}";
+			if ($action_addFlag != '') $script_action = $action_addFlag . $script_action;
+
+			$script_action = "{\r\n\t" . $script_action . "}";
 			$action_addFlag = '';
 			if($vacation == false)
 				$script_rules .= $script_match . $script_criteria . $script_action . "\r\n";
@@ -291,11 +292,11 @@ class FilterMapping
 			if($data['id'] != "vacation")
 				++$i;
 			$script_match = "";
-			$script_criteria = "";	
+			$script_criteria = "";
 			$script_action = "";
-			$data['applyMessages'] = "";	
+			$data['applyMessages'] = "";
 
-			$verifyNextRule = $data['verifyNextRule'];	
+			$verifyNextRule = $data['verifyNextRule'];
 		}
 
 		/*
@@ -303,11 +304,11 @@ class FilterMapping
 		{
 			// Para habilitar as funções desejadas, edite a diretiva sieve_extensions no arquivo de configuração "/etc/imapd.conf"
 			$script_header .= "require [";
-			$require_reject ? $script_header .= "\"reject\", " : ""; 
-			$require_fileinto ? $script_header .= "\"fileinto\", " : ""; 
-			$require_vacation? $script_header .= "\"vacation\", " : "";  
-			$require_flag ? $script_header .= "\"imapflags\", " : "";  
-			$require_body ? $script_header .= "\"body\", " : "";  
+			$require_reject ? $script_header .= "\"reject\", " : "";
+			$require_fileinto ? $script_header .= "\"fileinto\", " : "";
+			$require_vacation? $script_header .= "\"vacation\", " : "";
+			$require_flag ? $script_header .= "\"imapflags\", " : "";
+			$require_body ? $script_header .= "\"body\", " : "";
 			$script_header = substr($script_header,0,-2);
 			$script_header .= "];\r\n";
 		}
@@ -315,19 +316,19 @@ class FilterMapping
 
 		if( $vacation_action )
 		  $script_rules .= "vacation" . $vacation_action . "\r\n";
-		
 
-		foreach ($rules as &$values) {						
+
+		foreach ($rules as &$values) {
 			if($values['applyMessages'])
 				$this->msgs_apply[] = $values['applyMessages'];
 			$values['applyMessages'] = array();
 		}
-		
+
 		$json_data = json_encode($rules);
 		$script_begin = "#Generated by Expresso\r\n";
-		
+
 		$hasBody = $require_body? " \"body\", ":"";
-		
+
 		$script_header = "require [\"include\", \"envelope\", \"fileinto\", \"reject\", ".
 						 "\"vacation\", \"regex\", \"relational\",". $hasBody.
 						 "\"comparator-i;ascii-numeric\", \"imapflags\"];\r\n".
@@ -344,12 +345,12 @@ class FilterMapping
 	* @author     Consórcio Expresso Livre - 4Linux (www.4linux.com.br) e Prognus Software Livre (www.prognus.com.br)
 	* @sponsor    Caixa Econômica Federal
 	* @author     Airton Bordin Junior <airton@prognus.com.br>
-	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>	
+	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>
 	* @param      <$scriptName> <Regras do usuário>
 	* @return     <Regra do usuário parseada>
 	* @access     <public>
 	*/
-	public function readOldScript($scriptName) 
+	public function readOldScript($scriptName)
 	{
         // Recebe o conteúdo do array;
         $lines = array();
@@ -369,17 +370,17 @@ class FilterMapping
         $retorno['rule'] = array();
 
         $line = array_shift($lines);
-        while (isset($line)) { 
+        while (isset($line)) {
             foreach ($regexps as $regp) {
                 if (preg_match("/$regp/i", $line)) {
                     // Recebe todas as regras criadas no servidor;
                     if (preg_match("/#rule&&/i", $line)) {
-                        $retorno['rule'][] = ltrim($line) . "\n";                          
+                        $retorno['rule'][] = ltrim($line) . "\n";
                     }
 					if(preg_match("/#vacation/i",$line)) {
 						if(!preg_match("/&&off/i",$line)) {
 							$retorno['vacation'] = true;
-						} 
+						}
 					}
                 }
             }
@@ -388,10 +389,10 @@ class FilterMapping
         }
         return $retorno;
     }
-	
-	
-	
-	
+
+
+
+
 	/**
 	* Método que faz o parsing do Script Sieve, transformando em Array.
 	*
@@ -399,7 +400,7 @@ class FilterMapping
 	* @author     Consórcio Expresso Livre - 4Linux (www.4linux.com.br) e Prognus Software Livre (www.prognus.com.br)
 	* @sponsor    Caixa Econômica Federal
 	* @author     Airton Bordin Junior <airton@prognus.com.br>
-	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>	
+	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>
 	* @param      <String> <$script> <Script Sieve com as regras do usuário>
 	* @return     <Regras do usuário em Array>
 	* @access     <public>
@@ -409,18 +410,21 @@ class FilterMapping
 		$old_rule = strripos($script, "##PSEUDO script start");
 		/* Tem regra antiga */
 		if($old_rule) {
+			preg_match_all('/if.*\(.*\).*{/i', $script, $condicoes);
+			$condicoes = $condicoes[0];
+
 			$parsed_rule = $this->readOldScript($script);
-			$old_rules = array(); 
+			$old_rules = array();
 			$i_return = 0;
 			foreach ($parsed_rule['rule'] as $i => $value) {
 				$array_rule = explode("&&", $parsed_rule['rule'][$i]);
-				
+
 				$action_type = array();
 				$action_parameter = array();
 				$criteria_value = array();
 				$criteria_operator = array();
 				$criteria_field = array();
-					
+
 				$i_criteria = 0;
 				$i_action = 0;
 
@@ -432,8 +436,8 @@ class FilterMapping
 						++$i_action;
 						break;
 					case 'discard':
-						$action_type[$i_action] = 'discard';
-						$action_parameter[$i_action] = "";
+						$action_type[$i_action] = 'fileinto';
+						$action_parameter[$i_action] = "INBOX.Trash";
 						++$i_action;
 						break;
 					case 'folder':
@@ -446,13 +450,13 @@ class FilterMapping
 						$action_parameter[$i_action] = 'flagged';
 						++$i_action;
 						break;
-					case 'address': 
+					case 'address':
 						$action_type[$i_action] = 'redirect';
 						$action_parameter[$i_action] = $array_rule[7];
 						++$i_action;
 						break;
 					/* Somente para tratar casos em que a ação não é suportada */
-					default:	
+					default:
 						$action_type[$i_action] = 'setflag';
 						$action_parameter[$i_action] = 'flagged';
 						++$i_action;
@@ -469,41 +473,93 @@ class FilterMapping
 					$criteria_operator[$i_criteria] = '*';
 					$criteria_field[$i_criteria] = 'from';
 					++$i_criteria;
-				} 
+				}
 				if($array_rule[4] != "") {
 					$criteria_value[$i_criteria] = mb_convert_encoding ($array_rule[4],'UTF-8');
 					$criteria_operator[$i_criteria] = '*';
 					$criteria_field[$i_criteria] = 'to';
 					++$i_criteria;
-				} 
+				}
 				if($array_rule[5] != "") {
 					$criteria_value[$i_criteria] = mb_convert_encoding ($array_rule[5],'UTF-8');
 					$criteria_operator[$i_criteria] = '*';
 					$criteria_field[$i_criteria] = 'subject';
 					++$i_criteria;
 				}
+
+				// caso a regra migrada tenha mençao a tamanho de anexo
+				if ($array_rule[11] != '')
+				{
+					// a regra "amigavel" nao possui nenhuma mençao ao tipo de regra sendo
+					// aplicada ("menor" ou "maior"), entao precisamos pegar da regra do sieve
+					preg_match('/size\s+(?<criteria>:.*)\s(?<valor>\d+)/i', $condicoes[$i], $matches);
+					if (isset($matches['criteria']) && isset($matches['valor']))
+					{
+						// assume que eh "maior que" e inverte caso aplicavel
+						$criteria_operator[$i_criteria] = '>';
+						if (strtolower($matches['criteria']) == ':under')
+						{
+							$criteria_operator[$i_criteria] = '<';
+						}
+						$criteria_value[$i_criteria] = $matches['valor'];
+						$criteria_field[$i_criteria] = 'size';
+						++$i_criteria;
+					}
+				}
 				$old_retorno = array();
-				$old_retorno['isExact']  = true;
+				$old_retorno['isExact']  = 'false';
 				$old_retorno['name'] = 'regra_migrada_' . $array_rule[1];
-				
-				$old_retorno['criteria'] = array();				
+
+				$old_retorno['criteria'] = array();
 				foreach($criteria_value as $j => $value) {
 					$old_retorno['criteria'][$j] = array();
 					$old_retorno['criteria'][$j]['value'] = $criteria_value[$j];
 					$old_retorno['criteria'][$j]['operator'] = $criteria_operator[$j];
 					$old_retorno['criteria'][$j]['field'] = $criteria_field[$j];
 				}
-				
-				$old_retorno['actions'] = array();				
+
+				$old_retorno['actions'] = array();
 				foreach($action_parameter as $j => $value) {
 					$old_retorno['actions'][$j] = array();
 					$old_retorno['actions'][$j]['parameter'] = $action_parameter[$j];
 					$old_retorno['actions'][$j]['type'] = $action_type[$j];
 				}
-				
+
 				$old_retorno['enabled'] = ($array_rule[2] == 'ENABLED') ? 'true' : 'false';
 				$old_retorno['id'] = 'Regra_migrada_' . $i_return;
 				$old_retorno['applyMessages']  = '';
+
+				/**
+				 * significados/valores possiveis da flag "8" das regras
+				 * no array
+				 *
+				 * 1 - verificar a proxima regra;
+				 * 4 - atender todos criterios ("allof"/"and")
+				 * 8 - manter uma copia na caixa de entrada
+				 * 9 - verificar a proxima e manter uma copia
+				 * 12 - atender todos criterios e manter uma copia
+				 * 13 - atender todos criterios, manter uma copia e verificar a proxima regra
+				 *
+				 */
+
+				// caso verifique a proxima regra
+				if ($array_rule[8] == 1 || $array_rule[8] == 5 || $array_rule[8] == 9 || $array_rule[8] == 13)
+				{
+					$old_retorno['verifyNextRule'] = 'true';
+				}
+				// se marcar para atender todos criterios
+				if ($array_rule[8] == 4 || $array_rule[8] == 5 || $array_rule[8] == 12 || $array_rule[8] == 13)
+				{
+					$old_retorno['isExact'] = true;
+				}
+				// caso mantenha uma copia na caixa de entrada
+				if ($array_rule[8] == 8 || $array_rule[8] == 9 || $array_rule[8] == 12 || $array_rule[8] == 13)
+				{
+					$total = count($old_retorno['actions']);
+					$old_retorno['actions'][$total] = array();
+					$old_retorno['actions'][$total]['type'] = 'fileinto';
+					$old_retorno['actions'][$total]['parameter'] = 'INBOX';
+				}
 
 				$old_rules[$i_return] = $old_retorno;
 				++$i_return;
@@ -516,7 +572,7 @@ class FilterMapping
 				$old_retorno['enabled'] = 'true';
 				$old_retorno['applyMessages'] = array();
 				$old_retorno['isExact'] = "false";
-				$old_retorno['actions'] = array();			
+				$old_retorno['actions'] = array();
 				$old_retorno['actions'][0] = array();
 				$old_retorno['actions'][0]['parameter'] = "";
 				$old_retorno['actions'][0]['type'] = "vacation";
@@ -526,15 +582,15 @@ class FilterMapping
 				$old_retorno['criteria'][0]['operator'] = "";
 				$old_retorno['criteria'][0]['field'] = "vacation";
 				$old_rules[] = $old_retorno;
-			}			
+			}
 			return $old_rules;
-		} 
+		}
 		/* Não tem regra antiga */
 		$pos = strripos($script, "#PseudoScript#");
 		$pseudo_script = substr( $script, $pos+17 );
 
 		$return = json_decode( $pseudo_script, true );
-	
+
 		return $return;
 	}
 
@@ -547,15 +603,15 @@ class FilterMapping
 	* @author     Consórcio Expresso Livre - 4Linux (www.4linux.com.br) e Prognus Software Livre (www.prognus.com.br)
 	* @sponsor    Caixa Econômica Federal
 	* @author     Airton Bordin Junior <airton@prognus.com.br>
-	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>	
+	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>
 	* @access     <public>
 	*/
 	public function __construct()
-	{ 
+	{
 		$this->service = Controller::service("Sieve");
 	}
 
-	
+
 	/**
 	* Método que recupera as regras do usuário.
 	*
@@ -563,7 +619,7 @@ class FilterMapping
 	* @author     Consórcio Expresso Livre - 4Linux (www.4linux.com.br) e Prognus Software Livre (www.prognus.com.br)
 	* @sponsor    Caixa Econômica Federal
 	* @author     Airton Bordin Junior <airton@prognus.com.br>
-	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>	
+	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>
 	* @return     <Regras do usuário>
 	* @access     <public>
 	*/
@@ -577,7 +633,7 @@ class FilterMapping
 		return( $this->rules );
 	}
 
-	
+
 	/**
 	* Método que aplica o filtro para as mensagens do usuário.
 	*
@@ -585,26 +641,26 @@ class FilterMapping
 	* @author     Consórcio Expresso Livre - 4Linux (www.4linux.com.br) e Prognus Software Livre (www.prognus.com.br)
 	* @sponsor    Caixa Econômica Federal
 	* @author     Airton Bordin Junior <airton@prognus.com.br>
-	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>	
-	* @param      <$uri> 
-	* @param      <$result> 
-	* @param      <$criteria> 
-	* @param      <$original> 
+	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>
+	* @param      <$uri>
+	* @param      <$result>
+	* @param      <$criteria>
+	* @param      <$original>
 	* @access     <public>
 	*/
 	public function applySieveFilter( &$uri , &$result , &$criteria , $original  )
 	{
-		$rule_apply = array(); 
-			
+		$rule_apply = array();
+
 		$filter = Controller::read($uri);
 		$filter_ = $this->parseSieveScript($filter['content']);
-		
+
 		foreach ($filter_ as $f_) {
-			if($f_['id'] == $uri['id']) { 
+			if($f_['id'] == $uri['id']) {
 				$rule_apply	= $f_;
 			}
 		}
-				
+
 		$actions = array();
 		$actions['type'] = $rule_apply['actions'][0]['type'];
 		$actions['parameter'] = $rule_apply['actions'][0]['parameter'];
@@ -616,13 +672,13 @@ class FilterMapping
 		//$messages = $rule_apply['applyMessages'];
 		$messages = $this->msgs_apply[0];
 		$this->msgs_apply = array();
-			
+
 		$imap = Controller::service( 'Imap' );
-		$imap->apliSieveFilter($messages, $actions); 
+		$imap->apliSieveFilter($messages, $actions);
 		return $result;
 	}
 
-	
+
 	/**
 	* Método que lê o script do usuário.
 	*
@@ -630,20 +686,20 @@ class FilterMapping
 	* @author     Consórcio Expresso Livre - 4Linux (www.4linux.com.br) e Prognus Software Livre (www.prognus.com.br)
 	* @sponsor    Caixa Econômica Federal
 	* @author     Airton Bordin Junior <airton@prognus.com.br>
-	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>	
-	* @param      <$uri> 
-	* @param      <$result> 
-	* @param      <$criteria> 
-	* @param      <$original> 
+	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>
+	* @param      <$uri>
+	* @param      <$result>
+	* @param      <$criteria>
+	* @param      <$original>
 	* @return     <Script do usuário>
 	* @access     <public>
 	*/
 	public function readUserScript( &$uri , &$params , &$criteria , $original )
-	{  
+	{
 		$uri['id'] = $this->service->config['user'];
 	}
-  
-  
+
+
 	/**
 	* Método que seta o script do usuário.
 	*
@@ -651,11 +707,11 @@ class FilterMapping
 	* @author     Consórcio Expresso Livre - 4Linux (www.4linux.com.br) e Prognus Software Livre (www.prognus.com.br)
 	* @sponsor    Caixa Econômica Federal
 	* @author     Airton Bordin Junior <airton@prognus.com.br>
-	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>	
-	* @param      <$uri> 
-	* @param      <$result> 
-	* @param      <$criteria> 
-	* @param      <$original> 
+	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>
+	* @param      <$uri>
+	* @param      <$result>
+	* @param      <$criteria>
+	* @param      <$original>
 	* @return     <Script do usuário>
 	* @access     <public>
 	*/
@@ -686,7 +742,7 @@ class FilterMapping
 			     'active' => true );
 	}
 
-	
+
 	/**
 	* Método que deleta o script do usuário.
 	*
@@ -694,18 +750,18 @@ class FilterMapping
 	* @author     Consórcio Expresso Livre - 4Linux (www.4linux.com.br) e Prognus Software Livre (www.prognus.com.br)
 	* @sponsor    Caixa Econômica Federal
 	* @author     Airton Bordin Junior <airton@prognus.com.br>
-	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>	
-	* @param      <$uri> 
-	* @param      <$result> 
-	* @param      <$criteria> 
-	* @param      <$original> 
+	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>
+	* @param      <$uri>
+	* @param      <$result>
+	* @param      <$criteria>
+	* @param      <$original>
 	* @access     <public>
 	*/
 	public function deleteRule( &$uri, &$params, &$criteria, $original )
 	{
-		if( !$this->rules ) {	
+		if( !$this->rules ) {
 			$this->rules = $this->getRules();
-		}	  
+		}
 		$params['id'] = $uri['id'];
 
 		$rules = array();
@@ -715,7 +771,7 @@ class FilterMapping
 				$rules[] = $this->rules[$i];
 
 		$this->rules = $rules;
-		
+
 		$uri['id'] = '';
 
 		$params = array( 'name' => $this->service->config['user'],
@@ -724,11 +780,11 @@ class FilterMapping
 
 		$URI = Controller::URI( $uri['concept'], $this->service->config['user'] );
 		$this->service->update( $URI, $params );
-	
+
 		return( false );
 	}
 
-	
+
 	/**
 	* Método que pega o script do usuário.
 	*
@@ -736,16 +792,16 @@ class FilterMapping
 	* @author     Consórcio Expresso Livre - 4Linux (www.4linux.com.br) e Prognus Software Livre (www.prognus.com.br)
 	* @sponsor    Caixa Econômica Federal
 	* @author     Airton Bordin Junior <airton@prognus.com.br>
-	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>	
-	* @param      <$uri> 
-	* @param      <$result> 
-	* @param      <$criteria> 
-	* @param      <$original> 
+	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>
+	* @param      <$uri>
+	* @param      <$result>
+	* @param      <$criteria>
+	* @param      <$original>
 	* @return     <Script do usuário>
 	* @access     <public>
 	*/
 	public function getSieveRule( &$uri , &$params , &$criteria , $original )
-	{	  
+	{
 		$script = $this->parseSieveScript( $params['content'] );
 
 		foreach( $script as $i => $rule )
@@ -754,7 +810,7 @@ class FilterMapping
 				return( $params = $rule );
 	}
 
-	
+
 	/**
 	* Método que lista as regras do usuário.
 	*
@@ -762,118 +818,127 @@ class FilterMapping
 	* @author     Consórcio Expresso Livre - 4Linux (www.4linux.com.br) e Prognus Software Livre (www.prognus.com.br)
 	* @sponsor    Caixa Econômica Federal
 	* @author     Airton Bordin Junior <airton@prognus.com.br>
-	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>	
-	* @param      <$uri> 
-	* @param      <$result> 
-	* @param      <$criteria> 
-	* @param      <$original> 
+	* @author	  Gustavo Pereira dos Santos <gustavo@prognus.com.br>
+	* @param      <$uri>
+	* @param      <$result>
+	* @param      <$criteria>
+	* @param      <$original>
 	* @return     <Regras do usuário>
 	* @access     <public>
 	*/
 	public function listSieveRules( &$uri , &$params , &$criteria , $original  )
 	{
-		$return = $params = $this->parseSieveScript( $params[0]['content'] ); 
+		$return = $params = $this->parseSieveScript( $params[0]['content'] );
 		return( $return );
 	}
 
-	/** 
-	 * Método que insere no ldap as informações do vacation 
-	 * 
-	 * @license    http://www.gnu.org/copyleft/gpl.html GPL 
-	 * @author     Consórcio Expresso Livre - 4Linux (www.4linux.com.br) e Prognus Software Livre (www.prognus.com.br) 
-	 * @sponsor     Caixa Econômica Federal 
-	 * @author     Cristiano Corrêa Schmidt 
-	 * @param      <$uri> 
-	 * @param      <$result> 
-	 * @param      <$criteria> 
-	 * @param      <$original> 
-	 * @return     <void> 
-	 * @access     public 
-	 */ 
-	public function verifyVacationRule( &$uri , &$params , &$criteria , $original  ) 
-	{ 
-	    if( $original['properties']['id'] === 'vacation' ) 
-	    { 
-	    	
-	    	
+	/**
+	 * Método que insere no ldap as informações do vacation
+	 *
+	 * @license    http://www.gnu.org/copyleft/gpl.html GPL
+	 * @author     Consórcio Expresso Livre - 4Linux (www.4linux.com.br) e Prognus Software Livre (www.prognus.com.br)
+	 * @sponsor     Caixa Econômica Federal
+	 * @author     Cristiano Corrêa Schmidt
+	 * @param      <$uri>
+	 * @param      <$result>
+	 * @param      <$criteria>
+	 * @param      <$original>
+	 * @return     <void>
+	 * @access     public
+	 */
+	public function verifyVacationRule( &$uri , &$params , &$criteria , $original  )
+	{
+	    if( $original['properties']['id'] === 'vacation' )
+	    {
+
+
 	    	$userLdap     	= $_SESSION['phpgw_info']['expressomail']['email_server']['imapUsername'];
 	    	$passLdap  		= $_SESSION['phpgw_info']['expressomail']['email_server']['imapPassword'];
 	    	$hostLdap       = $_SESSION['phpgw_info']['expressomail']['server']['ldap_host'];
 	    	$contextoLdap	= $_SESSION['phpgw_info']['expressomail']['server']['ldap_context'];
 
-	        $user = Controller::read(array('concept' => 'user' , 'id' => config::me('uidNumber') , 'service' => 'OpenLDAP')); 
-	        $ldapConf = Config::service('OpenLDAP', 'config'); 
-	        $con = ldap_connect( $hostLdap ); 
-	        
+	        $user = Controller::read(array('concept' => 'user' , 'id' => config::me('uidNumber') , 'service' => 'OpenLDAP'));
+	        $ldapConf = Config::service('OpenLDAP', 'config');
+	        $con = ldap_connect( $hostLdap );
+
 	        ldap_set_option( $con,LDAP_OPT_PROTOCOL_VERSION, 3 );
 	        //die(print_r($user['dn'])." - ".$passLdap);
-	        ldap_bind( $con, $user['dn'], $passLdap); 
+	        ldap_bind( $con, $user['dn'], $passLdap);
 
-	        $info = array(); 
-	        if(!in_array('Vacation', $user['objectClass'])) 
-	                $info['objectClass'] = 'Vacation'; 
+	        $info = array();
+	        if(!in_array('Vacation', $user['objectClass']))
+	                $info['objectClass'] = 'Vacation';
 
 	        $info['vacationActive'] = strtoupper($original['properties']['enabled']);
-	        //die($info['vacationActive']); 
+	        //die($info['vacationActive']);
 
-	        if(isset($original['properties']['actions']) && isset($original['properties']['actions'][0]['parameter'])) 
-	                $info['vacationInfo']   = $original['properties']['actions'][0]['parameter']; 
-	        else if( !isset($user['vacationInfo']) ) 
-	        { 
-	            $rules = $this->getRules(); 
-	            if(is_array($rules)) 
-	                foreach ($rules as $rule) 
-	                if($rule['id'] === 'vacation') 
-	                	$info['vacationInfo'] = $rule['actions'][0]['parameter']; 
-	        } 
+	        if(isset($original['properties']['actions']) && isset($original['properties']['actions'][0]['parameter']))
+	                $info['vacationInfo']   = $original['properties']['actions'][0]['parameter'];
+	        else if( !isset($user['vacationInfo']) )
+	        {
+	            $rules = $this->getRules();
+	            if(is_array($rules))
+	                foreach ($rules as $rule)
+	                if($rule['id'] === 'vacation')
+	                	$info['vacationInfo'] = $rule['actions'][0]['parameter'];
+	        }
 
-	        
-	        
+
+
 	        if(!in_array('Vacation', $user['objectClass'])){
 	            if($info['vacationActive']==""){
 	            	$info['vacationActive']="TRUE";
-	            }    
+	            }
 	        	ldap_mod_add ( $con , $user['dn'] ,  $info );
-	        } 
-	        else{ 
+	        }
+	        else{
 	                ldap_modify ( $con , $user['dn'] ,  $info );
-	        } 
+	        }
 
 
-	        ldap_close($con); 
+	        ldap_close($con);
 
-	    } 
-	 
+	    }
+
 	}
 
-	/** 
-	 * Método que remove do ldap as informações do vacation 
-	 * 
-	 * @license    http://www.gnu.org/copyleft/gpl.html GPL 
-	 * @author     Consórcio Expresso Livre - 4Linux (www.4linux.com.br) e Prognus Software Livre (www.prognus.com.br) 
-	 * @sponsor     Caixa Econômica Federal 
-	 * @author     Cristiano Corrêa Schmidt 
-	 * @param      <$uri> 
-	 * @param      <$result> 
-	 * @param      <$criteria> 
-	 * @param      <$original> 
-	 * @return     <void> 
-	 * @access     public 
-	 */ 
-	public function deleteVacationRule( &$uri , &$params , &$criteria , $original  ) 
-	{         
-	    if( $original['URI']['id'] === 'vacation' ) 
-	    { 
-	        $user = Controller::read(array('concept' => 'user' , 'id' => config::me('uidNumber') , 'service' => 'OpenLDAP')); 
-	        $ldapConf = Config::service('OpenLDAP', 'config'); 
-	        $con = ldap_connect( $ldapConf['host'] ); 
-	        ldap_set_option( $con,LDAP_OPT_PROTOCOL_VERSION, 3 ); 
-	        ldap_bind( $con, $ldapConf['user'], $ldapConf['password']); 
-	        $info = array(); 
-	        $info['vacationActive'] = 'FALSE'; 
-	        $info['vacationInfo'] = ""; 
-	        ldap_modify ( $con , $user['dn'] ,  $info ); 
-	        ldap_close($con); 
-	    } 
+	/**
+	 * Método que remove do ldap as informações do vacation
+	 *
+	 * @license    http://www.gnu.org/copyleft/gpl.html GPL
+	 * @author     Consórcio Expresso Livre - 4Linux (www.4linux.com.br) e Prognus Software Livre (www.prognus.com.br)
+	 * @sponsor     Caixa Econômica Federal
+	 * @author     Cristiano Corrêa Schmidt
+	 * @param      <$uri>
+	 * @param      <$result>
+	 * @param      <$criteria>
+	 * @param      <$original>
+	 * @return     <void>
+	 * @access     public
+	 */
+	public function deleteVacationRule( &$uri , &$params , &$criteria , $original  )
+	{
+	    if( $original['URI']['id'] === 'vacation' )
+	    {
+	        $user = Controller::read(array('concept' => 'user' , 'id' => config::me('uidNumber') , 'service' => 'OpenLDAP'));
+	        $ldapConf = Config::service('OpenLDAP', 'config');
+	        $con = ldap_connect( $ldapConf['host'] );
+	        ldap_set_option( $con,LDAP_OPT_PROTOCOL_VERSION, 3 );
+	        ldap_bind( $con, $ldapConf['user'], $ldapConf['password']);
+	        $info = array();
+	        $info['vacationActive'] = 'FALSE';
+	        $info['vacationInfo'] = "";
+	        ldap_modify ( $con , $user['dn'] ,  $info );
+	        ldap_close($con);
+	    }
 	}
+
+   public function convert_specialchar($input) {
+		$temp_input = $input;
+		$temp_input = imap_8bit($temp_input);
+		$patterns[0] = '/ /';
+		$replacements[0] = '_';
+		$temp_input = preg_replace($patterns, $replacements, $temp_input);
+		return ($temp_input);
+    }
 }

--- a/prototype/rest/catalog/UserDynamicContactsResource.php
+++ b/prototype/rest/catalog/UserDynamicContactsResource.php
@@ -1,0 +1,58 @@
+<?php
+
+if (!defined('ROOTPATH'))
+    define('ROOTPATH', dirname(__FILE__) . '/..');
+
+use prototype\api\Config as Config;
+
+require_once(__DIR__ . '/../../modules/catalog/interceptors/CatalogDBMapping.php');
+/**
+ * Classe que fornece via REST que todos os contatos do usario no quais sao:
+ * - Contatos Dinâmicos
+ * - Contatos Pessoais
+ * - Grupos
+ * - Contatos Compartilhados
+ * - Grupos Compartilhados
+ */
+class UserDynamicContactsResource extends Resource
+{
+
+	/**
+    * Retorna todos os contatos que o usario possui para usar na busca dinamica.
+	* @return Retorna uma lista de Contatos Dinâmicos, Grupos, Contatos Pessoais, Grupos Compartilhados e Contatos Compartilhados
+	* @access     public
+	* */
+	function get($request)
+	{
+		$this->secured();
+
+		//verificar se a preferencia de contatos dinamicos nao esta ativada
+		if(!$this->isEnabledDynamicContacts()){
+			$response = new Response($request);
+			$response->addHeader('Content-type', 'aplication/json');
+			$response->code = Response::UNAUTHORIZED;
+			$response->body = 'disabled dynamic contacts preference';
+			return $response;
+		}
+
+	    $catalog = new CatalogDBMapping();
+		$contactsUser = $catalog->allContactsUser(Config::me("uidNumber"));
+
+		$response = new Response($request);
+		$response->addHeader('Content-type', 'aplication/json');
+		$response->code = Response::OK;
+		$response->body = json_encode($contactsUser);
+		return $response;
+
+	}
+
+    private function isEnabledDynamicContacts(){
+		$dynamicContactsEnable = $_SESSION['phpgw_info']['user']['preferences']['expressoMail']['use_dynamic_contacts'];
+		if($dynamicContactsEnable === '1')
+			return true;
+		else
+			return false;
+    }
+}
+
+?>


### PR DESCRIPTION
- Melhoria no desempenho no carregamento dos contatos dinâmicos;
- Correção na impressão da lista de emails;
- Correção no filtro de subject com caracteres especiais;
- Aumento da fonte do corpo de emails em texto plano;
- Omitir importar agenda para eventos do expresso;
- Correção no problema de salvar filtros e duplicar;
- E-mail com conteúdo extenso estava quebrando layout do expresso;
- Expresso não estava criando item MESSAGE-ID no cabeçalho dos e-mails enviados;
- Encaminhar um e-mail com anexo o Expresso não permitia remover o arquivo anexo;
- Expresso não está exibindo EML anexo;
- Ao excluir um email aberto, quando usuário está com outra pasta aberta, o Expresso não removia o email;
- Correção na função de mover emails de resultados de pesquis de marcadores;
